### PR TITLE
Handle optional chardet dependency

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,12 @@ import json
 import time
 from typing import Dict, List, Tuple, Optional
 
-import chardet
+try:
+    import chardet  # type: ignore
+    CHARDET_DETECT = chardet.detect
+except ImportError:  # pragma: no cover - optional dependency
+    chardet = None  # type: ignore
+    CHARDET_DETECT = None
 import numpy as np
 import pandas as pd
 import requests
@@ -168,12 +173,13 @@ def normalize_tag(s: str) -> str:
 def robust_read_csv(upload: bytes) -> pd.DataFrame:
     # Guess encoding
     enc = "utf-8"
-    try:
-        det = chardet.detect(upload)
-        if det and det.get("encoding"):
-            enc = det["encoding"]
-    except Exception:
-        enc = "utf-8"
+    if CHARDET_DETECT:
+        try:
+            det = CHARDET_DETECT(upload)
+            if det and det.get("encoding"):
+                enc = det["encoding"]
+        except Exception:
+            enc = "utf-8"
 
     # Try separators in order
     seps = [",", ";", "\t", "|"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ streamlit==1.37.0
 pandas==2.2.2
 numpy==1.26.4
 requests==2.32.3
-chardet==5.2.0
+chardet==5.2.0  # Recommended for CSV encoding detection


### PR DESCRIPTION
## Summary
- guard the optional chardet import and only attempt detection when the library is available
- document that chardet remains recommended for CSV encoding detection consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7025e0bc4832e8d22704da5be4fa5